### PR TITLE
fix dataset root

### DIFF
--- a/shift15m/constants.py
+++ b/shift15m/constants.py
@@ -1,6 +1,6 @@
 import pathlib
 
-repo_root = pathlib.Path(__file__).parent.parent
+repo_root = pathlib.Path(".")
 
 BASE_URL = "https://research.zozo.com/data_release/shift15m"
 JSONL = "jsonl"


### PR DESCRIPTION
If pip install this repository, the file reference will be under site(dist)-packages.
The dataset should be placed in home directory, so change the dataset root to current.